### PR TITLE
POC: running with OrientDB 3.0.3 in remote mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ graphdb-benchmarks.iml
 metrics/
 results/
 storage/
+
+*.iml
+idea/

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <blueprints.version>2.6.0</blueprints.version>
-        <orientdb.version>2.2.5-SNAPSHOT</orientdb.version>
+        <orientdb.version>3.0.3</orientdb.version>
         <titan.version>0.5.4</titan.version>
         <hbase.version>0.98.8-hadoop2</hbase.version>
         <neo4j.version>2.0.1</neo4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </scm>
 
     <properties>
-        <blueprints.version>2.6.0</blueprints.version>
+        <blueprints.version>3.3.0</blueprints.version>
         <orientdb.version>3.0.3</orientdb.version>
         <titan.version>0.5.4</titan.version>
         <hbase.version>0.98.8-hadoop2</hbase.version>
@@ -119,15 +119,15 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.gremlin</groupId>
+            <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-groovy</artifactId>
             <version>${blueprints.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.tinkerpop.gremlin</groupId>
-            <artifactId>gremlin-java</artifactId>
-            <version>${blueprints.version}</version>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>com.tinkerpop.gremlin</groupId>-->
+            <!--<artifactId>gremlin-java</artifactId>-->
+            <!--<version>${blueprints.version}</version>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>com.github.stephenc.high-scale-lib</groupId>
             <artifactId>high-scale-lib</artifactId>
@@ -164,8 +164,8 @@
             <version>${neo4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tinkerpop.blueprints</groupId>
-            <artifactId>blueprints-neo4j2-graph</artifactId>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>neo4j-gremlin</artifactId>
             <version>${blueprints.version}</version>
             <exclusions>
                 <exclusion>
@@ -177,12 +177,7 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-graphdb</artifactId>
-            <version>${orientdb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.tinkerpop</groupId>
-            <artifactId>pipes</artifactId>
-            <version>${blueprints.version}</version>
+            <version>3.0.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -247,11 +242,11 @@
             <artifactId>sparkseejava</artifactId>
             <version>5.0.0</version>
         </dependency>
-        <dependency>
-           <groupId>com.tinkerpop.blueprints</groupId>
-           <artifactId>blueprints-sparksee-graph</artifactId>
-           <version>${blueprints.version}</version>
-        </dependency>
+        <!--<dependency>-->
+           <!--<groupId>org.apache.tinkerpop</groupId>-->
+           <!--<artifactId>sparksee</artifactId>-->
+           <!--<version>${blueprints.version}</version>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/eu/socialsensor/graphdatabases/OrientGraphDatabase.java
+++ b/src/main/java/eu/socialsensor/graphdatabases/OrientGraphDatabase.java
@@ -49,14 +49,18 @@ public class OrientGraphDatabase extends GraphDatabaseBase<Iterator<Vertex>, Ite
     private OrientGraph graph = null;
     private boolean useLightWeightEdges;
     private String connectUrl;
+    private String username;
+    private String password;
 
     //
     public OrientGraphDatabase(BenchmarkConfiguration config, File dbStorageDirectoryIn)
     {
         super(GraphDatabaseType.ORIENT_DB, dbStorageDirectoryIn);
         OGlobalConfiguration.STORAGE_COMPRESSION_METHOD.setValue("nothing");
-        this.useLightWeightEdges = config.orientLightweightEdges();
-        this.connectUrl = config.orientRemoteDbUrl();
+        this.useLightWeightEdges = config.getOrientLightweightEdges();
+        this.connectUrl = config.getOrientRemoteDbUrl();
+        this.username = config.getOrientUserName();
+        this.password = config.getOrientPassword();
     }
 
     @Override
@@ -408,18 +412,25 @@ public class OrientGraphDatabase extends GraphDatabaseBase<Iterator<Vertex>, Ite
         });
     }
 
-    private OrientGraph getGraph(final File dbPath)
-    {
+    private OrientGraph getGraph(final String dbConnectUrl){
         OrientGraph g;
-        OrientGraphFactory graphFactory = new OrientGraphFactory("plocal:" + dbPath.getAbsolutePath());
+        OrientGraphFactory graphFactory;
+        if (username != null && password != null){
+            graphFactory = new OrientGraphFactory(dbConnectUrl, username, password);
+        } else {
+            graphFactory = new OrientGraphFactory(dbConnectUrl);
+        }
         g = graphFactory.getTx();
         g.setUseLightweightEdges(this.useLightWeightEdges);
         return g;
     }
 
-    private OrientGraph getGraph(final String url){
-        return new OrientGraph(url, "root", "admin");
+    private OrientGraph getGraph(final File dbPath)
+    {
+        return getGraph("plocal:" + dbPath.getAbsolutePath());
     }
+
+
 
     private OrientGraph getGraph(){
         return StringUtils.isNotEmpty(connectUrl) ? getGraph(connectUrl) : getGraph(dbStorageDirectory);

--- a/src/main/java/eu/socialsensor/insert/OrientMassiveInsertion.java
+++ b/src/main/java/eu/socialsensor/insert/OrientMassiveInsertion.java
@@ -32,7 +32,7 @@ public class OrientMassiveInsertion extends InsertionBase<Long> implements Inser
         }
         transactionlessGraph.shutdown();
 
-        graph = new OGraphBatchInsertBasic(url);
+        graph = new OGraphBatchInsertBasic(url, "root", "admin");
         graph.setAverageEdgeNumberPerNode(AVERAGE_NUMBER_OF_EDGES_PER_NODE);
         graph.setEstimatedEntries(ESTIMATED_ENTRIES);
         graph.setIdPropertyName("nodeId");

--- a/src/main/java/eu/socialsensor/main/BenchmarkConfiguration.java
+++ b/src/main/java/eu/socialsensor/main/BenchmarkConfiguration.java
@@ -89,6 +89,8 @@ public class BenchmarkConfiguration
     private final boolean dynamodbConsistentRead;
     private final Boolean orientLightweightEdges;
     private final String orientRemoteDbUrl;
+    private final String orientUserName;
+    private final String orientPassword;
     private final String sparkseeLicenseKey;
 
     // shortest path
@@ -113,7 +115,7 @@ public class BenchmarkConfiguration
     private final boolean dynamodbPrecreateTables;
     private final String dynamodbTablePrefix;
 
-    public String getDynamodbCredentialsFqClassName()
+  public String getDynamodbCredentialsFqClassName()
     {
         return dynamodbCredentialsFqClassName;
     }
@@ -166,8 +168,10 @@ public class BenchmarkConfiguration
         this.dynamodbTablePrefix = dynamodb.containsKey(TABLE_PREFIX) ? dynamodb.getString(TABLE_PREFIX) : Constants.DYNAMODB_TABLE_PREFIX.getDefaultValue();
 
         Configuration orient = socialsensor.subset("orient");
-        orientLightweightEdges = orient.containsKey(LIGHTWEIGHT_EDGES) ? orient.getBoolean(LIGHTWEIGHT_EDGES) : null;
-        orientRemoteDbUrl = orient.containsKey("connection-url") ? orient.getString("connection-url") : null;
+        orientLightweightEdges = orient.getBoolean(LIGHTWEIGHT_EDGES, null);
+        orientRemoteDbUrl = orient.getString("connection-url", null);
+        orientUserName = orient.getString("username", null);
+        orientPassword = orient.getString("password", null);
 
         Configuration sparksee = socialsensor.subset("sparksee");
         sparkseeLicenseKey = sparksee.containsKey(LICENSE_KEY) ? sparksee.getString(LICENSE_KEY) : null;
@@ -362,13 +366,21 @@ public class BenchmarkConfiguration
         return actualCommunities;
     }
 
-    public Boolean orientLightweightEdges()
+    public Boolean getOrientLightweightEdges()
     {
         return orientLightweightEdges;
     }
 
-    public String orientRemoteDbUrl() {
+    public String getOrientRemoteDbUrl() {
         return orientRemoteDbUrl;
+    }
+
+    public String getOrientUserName(){
+      return orientUserName;
+    }
+
+    public String getOrientPassword(){
+      return orientPassword;
     }
 
     public String getSparkseeLicenseKey()

--- a/src/main/java/eu/socialsensor/main/BenchmarkConfiguration.java
+++ b/src/main/java/eu/socialsensor/main/BenchmarkConfiguration.java
@@ -88,6 +88,7 @@ public class BenchmarkConfiguration
     private final BackendDataModel dynamodbDataModel;
     private final boolean dynamodbConsistentRead;
     private final Boolean orientLightweightEdges;
+    private final String orientRemoteDbUrl;
     private final String sparkseeLicenseKey;
 
     // shortest path
@@ -166,6 +167,7 @@ public class BenchmarkConfiguration
 
         Configuration orient = socialsensor.subset("orient");
         orientLightweightEdges = orient.containsKey(LIGHTWEIGHT_EDGES) ? orient.getBoolean(LIGHTWEIGHT_EDGES) : null;
+        orientRemoteDbUrl = orient.containsKey("connection-url") ? orient.getString("connection-url") : null;
 
         Configuration sparksee = socialsensor.subset("sparksee");
         sparkseeLicenseKey = sparksee.containsKey(LICENSE_KEY) ? sparksee.getString(LICENSE_KEY) : null;
@@ -363,6 +365,10 @@ public class BenchmarkConfiguration
     public Boolean orientLightweightEdges()
     {
         return orientLightweightEdges;
+    }
+
+    public String orientRemoteDbUrl() {
+        return orientRemoteDbUrl;
     }
 
     public String getSparkseeLicenseKey()

--- a/src/test/resources/META-INF/input.properties
+++ b/src/test/resources/META-INF/input.properties
@@ -65,6 +65,8 @@ eu.socialsensor.dynamodb.endpoint=http://127.0.0.1:4567
 # OrientDB options
 eu.socialsensor.orient.lightweight-edges=true
 eu.socialsensor.orient.connection-url=remote:localhost/stress-test
+eu.socialsensor.orient.username=root
+eu.socialsensor.orient.password=admin
 
 # Sparksee options
 eu.socialsensor.sparksee.license-key=DEADBEEF

--- a/src/test/resources/META-INF/input.properties
+++ b/src/test/resources/META-INF/input.properties
@@ -1,11 +1,11 @@
 # Choose which data sets you want to include in the benchmark by removing the contents.
-#eu.socialsensor.dataset=data/Email-Enron.txt
+eu.socialsensor.dataset=data/Email-Enron.txt
 #eu.socialsensor.dataset=data/com-youtube.ungraph.txt
 #eu.socialsensor.dataset=data/Amazon0601.txt
 #eu.socialsensor.dataset=data/com-lj.ungraph.txt
 #can change the number in the filename of the synthetic datasets to 1000, 5000, 10000, 20000, 30000, 40000, 50000
-eu.socialsensor.dataset=data/network1000.dat
-eu.socialsensor.actual-communities=data/community1000.dat
+#eu.socialsensor.dataset=data/network1000.dat
+#eu.socialsensor.actual-communities=data/community1000.dat
 
 eu.socialsensor.database-storage-directory=storage
 # Sample meters this frequently (milliseconds)
@@ -17,13 +17,13 @@ eu.socialsensor.metrics.csv.directory=metrics
 
 # Choose which databases you want to in the benchmark by removing the comments.
 # Available dbs are:
-eu.socialsensor.databases=tbdb
-eu.socialsensor.databases=tddb
+#eu.socialsensor.databases=tbdb
+#eu.socialsensor.databases=tddb
 #eu.socialsensor.databases=tc
 #eu.socialsensor.databases=thb
 #eu.socialsensor.databases=tce
 #eu.socialsensor.databases=tp
-#eu.socialsensor.databases=orient
+eu.socialsensor.databases=orient
 #eu.socialsensor.databases=neo4j
 #eu.socialsensor.databases=sparksee
 
@@ -64,6 +64,7 @@ eu.socialsensor.dynamodb.endpoint=http://127.0.0.1:4567
 
 # OrientDB options
 eu.socialsensor.orient.lightweight-edges=true
+eu.socialsensor.orient.connection-url=remote:localhost/stress-test
 
 # Sparksee options
 eu.socialsensor.sparksee.license-key=DEADBEEF


### PR DESCRIPTION
Hello

My team at B-yond is evaluating OrientDB as a database for analyzing communication networks. To verify our architecture, we have decided to do an early performance test.

I came up on your (very impressive) benchmark and would like to ask for advice on running it with our setup.

We are running OrientDB 3.0.3 Community Edition with Gremlin Server (https://github.com/orientechnologies/orientdb-docker/blob/3d7d8070e903149126c7d691afa3be5f2de58742/3.0-tp3/x86_64/alpine/Dockerfile) in distributed mode in a Kubernetes cluster. The actual communication with the database would go through a network connection, so it seems to me that remote mode is appropriate here. 


To that end, I've made the changes in this PR. When I run this setup through `mvn test -Pbench`, the following exception happens:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running eu.socialsensor.main.GraphDatabaseBenchmarkTest
14:17:27.342 [main] INFO  GraphDatabaseBenchmark - Massive Insertion Benchmark Selected
14:17:27.345 [main] INFO  PermutingBenchmarkBase - Executing Massive Insertion Benchmark . . . .
Jul 10, 2018 2:17:27 PM com.orientechnologies.common.log.OLogManager log
INFO: Default limit of open files (512) will be used.
java.lang.UnsupportedOperationException
        at com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx.exists(ODatabaseDocumentTx.java:1065)
        at com.orientechnologies.orient.graph.batch.OGraphBatchInsertBasic.begin(OGraphBatchInsertBasic.java:187)
        at eu.socialsensor.insert.OrientMassiveInsertion.<init>(OrientMassiveInsertion.java:39)
        at eu.socialsensor.graphdatabases.OrientGraphDatabase.massiveModeLoading(OrientGraphDatabase.java:94)
        at eu.socialsensor.benchmarks.MassiveInsertionBenchmark.benchmarkOne(MassiveInsertionBenchmark.java:45)
        at eu.socialsensor.benchmarks.PermutingBenchmarkBase.startBenchmarkInternalOnePermutation(PermutingBenchmarkBase.java:68)
        at eu.socialsensor.benchmarks.PermutingBenchmarkBase.startBenchmarkInternal(PermutingBenchmarkBase.java:57)
        at eu.socialsensor.benchmarks.BenchmarkBase.startBenchmark(BenchmarkBase.java:35)
        at eu.socialsensor.main.GraphDatabaseBenchmark.runBenchmark(GraphDatabaseBenchmark.java:136)
        at eu.socialsensor.main.GraphDatabaseBenchmark.run(GraphDatabaseBenchmark.java:101)
        at eu.socialsensor.main.GraphDatabaseBenchmarkTest.testGraphDatabaseBenchmark(GraphDatabaseBenchmarkTest.java:14)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 8.689 sec <<< FAILURE! - in eu.socialsensor.main.GraphDatabaseBenchmarkTest
testGraphDatabaseBenchmark(eu.socialsensor.main.GraphDatabaseBenchmarkTest)  Time elapsed: 8.688 sec  <<< FAILURE!
java.lang.AssertionError: Got unexpected exception: null
        at org.junit.Assert.fail(Assert.java:88)
        at eu.socialsensor.main.GraphDatabaseBenchmarkTest.testGraphDatabaseBenchmark(GraphDatabaseBenchmarkTest.java:19)
```

The exception is coming form a deprecated class: `com/orientechnologies/orientdb-core/3.0.3/orientdb-core-3.0.3.jar!/com/orientechnologies/orient/core/db/document/ODatabaseDocumentTx.class:995`

What should be used instead of it?

Thank you

Eli
